### PR TITLE
Add support for GNOME Shell 46-49 (Ubuntu 24.04 LTS compatibility)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,5 +2,5 @@
   "uuid": "simple-tiling@tubbe",
   "name": "Simple Tiling",
   "description": "Automatic tiling window manager for GNOME Shell. Divides windows into non-overlapping tiles using binary space partitioning.",
-  "shell-version": ["49"]
+  "shell-version": ["46", "47", "48", "49"]
 }


### PR DESCRIPTION
Extended shell-version in metadata.json to include GNOME 46, 47, 48, and 49. This enables the extension to work on Ubuntu 24.04 LTS which ships with GNOME 46.

The code already uses modern APIs compatible with these versions:
- Mtk.Rectangle (not deprecated Meta.Rectangle)
- unmaximize() without parameters
- ESM module imports
- Modern Extension base class